### PR TITLE
Localization and guest posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ FluxBB v1.5.8 or above
 
 1. Upload `plugins/AP_reCAPTCHA.php`.
 2. Upload `addons/recaptcha.php`.
+3. Upload `lang/English/recaptcha_plugin.php`.
 
 ## Configuration
 
 After installation, head to your FluxBB administration panel.
 In the left-hand menu, under "Plugins" select "reCAPTCHA".
-Enter your credentials as provided by Google and save.
+Enter your credentials as provided by Google, enable reCAPTCHA and save.
 The addon should now start working.
 Head to the registration page to confirm everything is okay.

--- a/lang/English/recaptcha_plugin.php
+++ b/lang/English/recaptcha_plugin.php
@@ -1,0 +1,14 @@
+<?php
+
+    $lang_recaptcha = array(
+        'Human'           => 'Are you a human?',
+        'Prove'           => 'Please prove that you\'re a human being.',
+        'Configure'       => 'Configure reCAPTCHA integration',
+        'Keys_desc'       => 'Please provide your reCAPTCHA account credentials as provided by Google.',
+        'Site_key'        => 'Site key',
+        'Secret_key'      => 'Secret key',
+        'Enable'          => 'Enable/Disable reCAPTCHA',
+        'Error'           => 'Please prove that you are human.',
+        'API error'       => 'Cannot validate reCAPTCHA submission.',
+        'Settings saved'  => 'Settings saved successfully. Redirecting...'
+    );

--- a/plugins/AP_reCAPTCHA.php
+++ b/plugins/AP_reCAPTCHA.php
@@ -4,6 +4,7 @@
  * New reCAPTCHA plugin for FluxBB
  *
  * Created by Franz Liedke
+ * Contributors: Quy, virtueless
  */
 
 // Make sure no one attempts to run this script "directly"
@@ -13,14 +14,20 @@ if (!defined('PUN'))
 // Tell admin_loader.php that this is indeed a plugin and that it is loaded
 define('PUN_PLUGIN_LOADED', 1);
 
+// Load language file
+if (file_exists(PUN_ROOT.'lang/'.$pun_user['language'].'/recaptcha_plugin.php'))
+    require PUN_ROOT.'lang/'.$pun_user['language'].'/recaptcha_plugin.php';
+else
+    require PUN_ROOT.'lang/English/recaptcha_plugin.php';
 
 // Store the config
 if (isset($_POST['process_form']))
 {
-    $site_key = isset($_POST['recaptcha_site_key']) ? pun_trim($_POST['recaptcha_site_key']) : '';
+    $site_key   = isset($_POST['recaptcha_site_key']) ? pun_trim($_POST['recaptcha_site_key']) : '';
     $secret_key = isset($_POST['recaptcha_secret_key']) ? pun_trim($_POST['recaptcha_secret_key']) : '';
+    $enabled    = isset($_POST['recaptcha_enabled']) ? 1 : 0;
 
-    foreach (compact('site_key', 'secret_key') as $key => $value)
+    foreach (compact('site_key', 'secret_key', 'enabled') as $key => $value)
     {
         $key = 'recaptcha_'.$key;
 
@@ -36,12 +43,17 @@ if (isset($_POST['process_form']))
 
     generate_config_cache();
 
-    redirect('admin_loader.php?plugin=AP_reCAPTCHA.php', 'Settings saved successfully. Redirecting...');
+    redirect('admin_loader.php?plugin=AP_reCAPTCHA.php', $lang_recaptcha['Settings saved']);
 }
 
 
 // Display the admin navigation menu
 generate_admin_menu($plugin);
+
+// Is reCAPTCHA enabled?
+$is_enabled = !empty($pun_config['recaptcha_enabled']);
+$checked    = $is_enabled ? 'checked' : '';
+$status     = $is_enabled ? '<span style="display:inline;color:green">Enabled</span>' : '<span style="display:inline;color:red">Disabled</span>';
 
 ?>
 
@@ -51,20 +63,28 @@ generate_admin_menu($plugin);
         <form id="recaptcha" method="post" action="<?php echo $_SERVER['REQUEST_URI'] ?>">
             <div class="inform">
                 <fieldset>
-                    <legend>Configure reCAPTCHA integration</legend>
+                    <legend><?= $lang_recaptcha['Configure']; ?></legend>
                     <div class="infldset">
+                        <table class="aligntop" cellspacing="0">
+                            <tr>
+                                <th scope="row"><?= $lang_recaptcha['Enable']; ?></th>
+                                <td>
+                                    <input type="checkbox" name="recaptcha_enabled" <?= $checked ?>> <?= $status ?><br>
+                                </td>
+                            </tr>
+                        </table>
                         <p>
-                            Please provide your reCAPTCHA account credentials as provided by Google.
+                            <?= $lang_recaptcha['Keys_desc']; ?>
                         </p>
                         <table class="aligntop" cellspacing="0">
                             <tr>
-                                <th scope="row">Site key</th>
+                                <th scope="row"><?= $lang_recaptcha['Site_key']; ?></th>
                                 <td>
                                     <input type="text" name="recaptcha_site_key" size="40" value="<?php if (!empty($pun_config['recaptcha_site_key'])) echo pun_htmlspecialchars($pun_config['recaptcha_site_key']); ?>" />
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row">Secret key</th>
+                                <th scope="row"><?= $lang_recaptcha['Secret_key']; ?></th>
                                 <td>
                                     <input type="text" name="recaptcha_secret_key" size="40" value="<?php if (!empty($pun_config['recaptcha_secret_key'])) echo pun_htmlspecialchars($pun_config['recaptcha_secret_key']); ?>" />
                                 </td>


### PR DESCRIPTION
Hi,
I deleted my "complicated" first fork to remake a simpler one, more in phase with the original idea.

I added localization so people can easily translate the plugin to their own language.

I added new manager bindings in 'addons/recaptcha.php' under the condition guest posting is allowed and the user is indeed a guest. It's displayed on new topics, new posts and quickreplies.

In the administration area, I added a enable/disable button so people can easily switch without having to remove/add their Google API keys.

Again, first time on GitHub, hope everything's fine!
